### PR TITLE
Remove computation of BM25 and Dirichlet score from CascadeEval

### DIFF
--- a/src/java/main/ivory/smrf/model/GlobalTermEvidence.java
+++ b/src/java/main/ivory/smrf/model/GlobalTermEvidence.java
@@ -23,8 +23,8 @@ package ivory.smrf.model;
  *
  */
 public class GlobalTermEvidence {
-	private int df;
-	private long cf;
+	public int df;
+	public long cf;
 
 	public GlobalTermEvidence() {
 		df = 0;

--- a/src/java/main/ivory/smrf/model/score/BM25ScoringFunction.java
+++ b/src/java/main/ivory/smrf/model/score/BM25ScoringFunction.java
@@ -55,6 +55,7 @@ public class BM25ScoringFunction extends ScoringFunction {
 
 	@Override
 	public void initialize(GlobalTermEvidence termEvidence, GlobalEvidence globalEvidence) {
+	  super.initialize(termEvidence, globalEvidence);
 		avgDocLen = (float) globalEvidence.collectionLength / (float) globalEvidence.numDocs;
 
 		if ("none".equals(idfType)) {

--- a/src/java/main/ivory/smrf/model/score/CascadeBM25ScoringFunction.java
+++ b/src/java/main/ivory/smrf/model/score/CascadeBM25ScoringFunction.java
@@ -1,11 +1,11 @@
 /*
  * Ivory: A Hadoop toolkit for web-scale information retrieval
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may
  * obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0 
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,47 +18,38 @@ package ivory.smrf.model.score;
 
 import ivory.smrf.model.GlobalEvidence;
 import ivory.smrf.model.GlobalTermEvidence;
-import ivory.util.XMLTools;
 import ivory.util.RetrievalEnvironment;
 
 import org.w3c.dom.Node;
 
 /**
  * @author Lidan Wang
- * 
  */
 public class CascadeBM25ScoringFunction extends BM25ScoringFunction {
+  public static float staticK1;
+  public static float staticB;
 
-        public static float K1;
-        public static float B;
-        public static float avg_docLen;
+  @Override
+  public void configure(Node domNode) {
+    super.configure(domNode);
+    staticK1 = k1;
+    staticB = b;
+  }
 
-	@Override
-	public void configure(Node domNode) {
-		super.configure(domNode);
-		K1 = k1;
-                B = b; 
-	}
+  @Override
+  public void initialize(GlobalTermEvidence termEvidence, GlobalEvidence globalEvidence) {
+    super.initialize(termEvidence, globalEvidence);
+  }
 
-	@Override
-	public void initialize(GlobalTermEvidence termEvidence, GlobalEvidence globalEvidence) {
+  @Override
+  public float getScore(int tf, int docLen) {
+    float bm25TF = 0;
 
-		super.initialize(termEvidence, globalEvidence); 
-		avg_docLen = avgDocLen;
-	}
+    if (RetrievalEnvironment.mIsNewModel) {
+      bm25TF = ((staticK1 + 1.0f) * tf) / (staticK1 * ((1.0f - staticB) + staticB * docLen / avgDocLen) + tf);
+      return bm25TF * idf;
+    }
 
-        @Override
-        public float getScore(int tf, int docLen) {
-                float bm25TF = 0;
- 
-                if (RetrievalEnvironment.mIsNewModel){
-                        bm25TF = ((K1 + 1.0f) * tf) / (K1 * ((1.0f - B) + B * docLen / avg_docLen) + tf);
-                }
-                else{
-                        bm25TF = ((k1 + 1.0f) * tf) / (k1 * ((1.0f - b) + b * docLen / avgDocLen) + tf);
-                }
- 
-                return bm25TF * idf;
-        }
-
+    return super.getScore(tf, docLen);
+  }
 }

--- a/src/java/main/ivory/smrf/model/score/CascadeDirichletScoringFunction.java
+++ b/src/java/main/ivory/smrf/model/score/CascadeDirichletScoringFunction.java
@@ -1,11 +1,11 @@
 /*
  * Ivory: A Hadoop toolkit for web-scale information retrieval
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may
  * obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0 
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,6 @@
 
 package ivory.smrf.model.score;
 
-import ivory.smrf.model.GlobalEvidence;
-import ivory.smrf.model.GlobalTermEvidence;
-import ivory.util.XMLTools;
 import ivory.util.RetrievalEnvironment;
 
 import org.w3c.dom.Node;
@@ -28,38 +25,25 @@ import org.w3c.dom.Node;
  * 
  */
 public class CascadeDirichletScoringFunction extends DirichletScoringFunction {
+  private static float staticMU;
 
-        private static float MU;
+  @Override
+  public void configure(Node domNode) {
+    super.configure(domNode);
+    staticMU = mu;
+  }
 
-	
-	@Override
-	public synchronized void configure(Node domNode) {
-		super.configure(domNode);
-		MU = mu;
-	}
+  @Override
+  public float getScore(int tf, int docLen) {
+    if (isOOV) {
+      return 0.0f;
+    }
 
+    // Since cascade is trained this way (term and term proximity features have same mu)
+    if (RetrievalEnvironment.mIsNewModel) {
+      return (float) Math.log(((float) tf + staticMU * backgroundProb) / (docLen + staticMU));
+    }
 
-        @Override
-        public float getScore(int tf, int docLen) {
-//          if ( MU != mu ) {
-//            throw new RuntimeException("MU=" + MU + ", mu=" + mu + ", " + RetrievalEnvironment.mIsNewModel);
-//          }
-                if (isOOV) {
-                        return 0.0f;
-                }
-
-                //Since cascade is trained this way (term and term proximity features have same mu)
-                if (RetrievalEnvironment.mIsNewModel){
-                        return (float) Math.log(((float) tf + MU * backgroundProb) / (docLen + MU));
-                }
-                else{
-                        return (float) Math.log(((float) tf + mu * backgroundProb) / (docLen + mu));
-                }
-        }
-
-//	@Override
-//	public void initialize(GlobalTermEvidence termEvidence, GlobalEvidence globalEvidence) {
-//		super.initialize(termEvidence, globalEvidence);
-//		collectionLength = (float) globalEvidence.collectionLength;
-//	}
+    return super.getScore(tf, docLen);
+  }
 }

--- a/src/java/main/ivory/smrf/model/score/CascadeDirichletScoringFunction.java
+++ b/src/java/main/ivory/smrf/model/score/CascadeDirichletScoringFunction.java
@@ -29,13 +29,11 @@ import org.w3c.dom.Node;
  */
 public class CascadeDirichletScoringFunction extends DirichletScoringFunction {
 
-        public static float MU;
-
-	public static float collectionLength;
+        private static float MU;
 
 	
 	@Override
-	public void configure(Node domNode) {
+	public synchronized void configure(Node domNode) {
 		super.configure(domNode);
 		MU = mu;
 	}
@@ -43,6 +41,9 @@ public class CascadeDirichletScoringFunction extends DirichletScoringFunction {
 
         @Override
         public float getScore(int tf, int docLen) {
+//          if ( MU != mu ) {
+//            throw new RuntimeException("MU=" + MU + ", mu=" + mu + ", " + RetrievalEnvironment.mIsNewModel);
+//          }
                 if (isOOV) {
                         return 0.0f;
                 }
@@ -56,9 +57,9 @@ public class CascadeDirichletScoringFunction extends DirichletScoringFunction {
                 }
         }
 
-	@Override
-	public void initialize(GlobalTermEvidence termEvidence, GlobalEvidence globalEvidence) {
-		super.initialize(termEvidence, globalEvidence);
-		collectionLength = (float) globalEvidence.collectionLength;
-	}
+//	@Override
+//	public void initialize(GlobalTermEvidence termEvidence, GlobalEvidence globalEvidence) {
+//		super.initialize(termEvidence, globalEvidence);
+//		collectionLength = (float) globalEvidence.collectionLength;
+//	}
 }

--- a/src/java/main/ivory/smrf/model/score/DirichletScoringFunction.java
+++ b/src/java/main/ivory/smrf/model/score/DirichletScoringFunction.java
@@ -50,6 +50,7 @@ public class DirichletScoringFunction extends ScoringFunction {
 
 	@Override
 	public void initialize(GlobalTermEvidence termEvidence, GlobalEvidence globalEvidence) {
+	  super.initialize(termEvidence, globalEvidence);
 		isOOV = termEvidence.getCf() == 0 ? true : false;
 		backgroundProb = (float) termEvidence.getCf() / (float) globalEvidence.collectionLength;
 	}

--- a/src/java/main/ivory/smrf/model/score/ScoringFunction.java
+++ b/src/java/main/ivory/smrf/model/score/ScoringFunction.java
@@ -31,6 +31,9 @@ import com.google.common.base.Preconditions;
  *
  */
 public abstract class ScoringFunction {
+  protected GlobalTermEvidence termEvidence;
+  protected GlobalEvidence globalEvidence;
+  
 	/**
 	 * Configures this scoring function.
 	 */
@@ -39,7 +42,18 @@ public abstract class ScoringFunction {
 	/**
 	 * Initializes this scoring function with global evidence.
 	 */
-	public void initialize(GlobalTermEvidence termEvidence, GlobalEvidence globalEvidence) {}
+	public void initialize(GlobalTermEvidence termEvidence, GlobalEvidence globalEvidence) {
+	  this.termEvidence = termEvidence;
+	  this.globalEvidence = globalEvidence;
+	}
+
+	public GlobalEvidence getGlobalEvidence() {
+	  return globalEvidence;
+	}
+
+	public GlobalTermEvidence getGlobalTermEvidence() {
+	  return termEvidence;
+	}
 
 	/**
 	 * Computes score.


### PR DESCRIPTION
CascadeEval has BM25 and Dirichlet score computation embedded inside it. Refactoring to "route" the score computations back to the actual ScoringFunctions.
